### PR TITLE
Address OpenSSL build failure

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <math.h>
 #include <node_api.h>
+#include <openssl/configuration.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,8 @@
   "targets": [
     {
       "target_name": "binding",
-      "sources": [ "binding.c" ]
+      "sources": [ "binding.c" ],
+      "defines": [ "OPENSSL_API_COMPAT=OPENSSL_CONFIGURED_API" ]
     },
     {
       "target_name": "copy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronomon/crypto-async",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Fast, reliable cipher, hash and hmac methods executed in Node's threadpool for multi-core throughput.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- Address OpenSSL build error due to missing configuration header

```
error: "OPENSSL_API_COMPAT expresses an impossible API compatibility level"
```

- Set `OPENSSL_API_COMPAT` level to match `OPENSSL_CONFIGURED_API`, not sure why this needs to be set as [this should be default](https://github.com/openssl/openssl/blob/1c0eede9827b0962f1d752fa4ab5d436fa039da4/include/openssl/macros.h#L86)

##### NOTE: Was using _nodejs 17.0.1_